### PR TITLE
Detect user setup parallel backend

### DIFF
--- a/R/register-parallel.R
+++ b/R/register-parallel.R
@@ -30,7 +30,10 @@ register_parallel <- function(ncores, ...) {
   if (identical(parent.frame(), globalenv()))
     stop2("This function must be used inside another function.")
 
-  if (ncores == 1) {
+  if (foreach::getDoParWorkers() > 1) {
+    # User has already registered a parallel backend in their R session, so we can just use that
+    # instead of setting up our own for the callee function
+  } else if (ncores == 1) {
     foreach::registerDoSEQ()
   } else {
     cl <- parallel::makeCluster(ncores, ...)

--- a/R/register-parallel.R
+++ b/R/register-parallel.R
@@ -41,6 +41,9 @@ register_parallel <- function(ncores, ...) {
     # https://stackoverflow.com/a/20998531/6103040
     do.call("on.exit", list(substitute(parallel::stopCluster(cl)), add = TRUE),
             envir = parent.frame())
+    # https://stackoverflow.com/questions/25097729/un-register-a-doparallel-cluster
+    do.call("on.exit", list(substitute(foreach::registerDoSeq()), add = TRUE),
+            envir = parent.frame())
   }
 
   invisible(NULL)


### PR DESCRIPTION
If the user has already registered a parallel backend for foreach in their R session (e.g. via `doMC::registerDoMC()` or `doParallel:registerDoParallel()`) then this is now detected, and that parallel backend used, instead of setting up a new one and clobbering the user's existing parallel backend.

Fix for https://github.com/privefl/bigsnpr/issues/251